### PR TITLE
Build `istaritags` in `make smlnj`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ smlnj :
 	cd cmlibi; make smlnj
 	cd ui; mkdir -p bin; make batch-nolib
 	cd library; make
-	cd ui; make server batch server-nolib
+	cd ui; make server batch server-nolib istaritags
 
 .PHONY : install
 install :
@@ -24,4 +24,3 @@ clean :
 	cd prover; make clean
 	cd ui; make clean
 	cd library; make clean
-

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,7 +1,7 @@
 
 include ../Makefile.inc
 
-all : batch-nolib server-nolib batch server
+all : batch-nolib server-nolib istaritags batch server
 
 .PHONY : generated
 generated : lexrepl-nj.cmlex.sml


### PR DESCRIPTION
Otherwise `make install` fails