### PR TITLE
Adding option subtyping to the registry

### DIFF
--- a/library/option-aux.iml
+++ b/library/option-aux.iml
@@ -1,1 +1,15 @@
-(* empty *)
+functor AfterSubtype () :> sig end =
+struct
+    val Collapse (option, option_subtype) =
+        readRegistry /Option.AfterSubtype/
+        /[constant constant]/
+
+    val () =
+        List.app Registry.delete
+        (parseLongidents
+            /Option.AfterSubtype/)
+
+    val () =
+        Constant2Table.insert TypecheckInternal.subtypeTactics (option, option)
+        (Backchain.applyRaw /\Term.Const option_subtype\/)
+end

--- a/library/option-load.iml
+++ b/library/option-load.iml
@@ -1,2 +1,4 @@
 
 File.import "option-deps.iml";
+File.import "option-aux.iml";
+structure Nothing = AfterSubtype () ;

--- a/library/option.ist
+++ b/library/option.ist
@@ -1,6 +1,7 @@
 
 Ctrl.use "datatypes.iml";
 
+File.import "option-aux.iml";
 
 beginModule "Option";
 
@@ -136,3 +137,18 @@ reductions
   valof _ (Some x) _ --> x ;
   unfolding valof
 /;
+
+lemma "option_subtype"
+/
+  intersect i (A B : U i) .
+  A <: B -> option A <: option B
+/;
+intro /i A B sub {| x}/ >> auto.
+qed();
+
+val option = parseConstant /option/;
+val option_subtype = parseConstant /option_subtype/;
+writeRegistry /AfterSubtype/
+  /[constant constant]/
+  (Collapse (option , option_subtype));
+structure Nothing = AfterSubtype () ;


### PR DESCRIPTION
Adding the `option_subtype` lemma into the `TypecheckInternal.subtypeTactics` registry so that `option A <: option B` gets typechecked to needing to show `A <: B` instead of `option A = option B`